### PR TITLE
End to End Test Dune to Postgres

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started
@@ -29,8 +29,7 @@ jobs:
       - name: Install Requirements
         run: pip install -r requirements/dev.txt
       - name: Tests
-        run: python -m pytest tests/e2e.py
+        run: python -m pytest tests/e2e_test.py
         # Environment variables used by the `pg_client.py`
         env:
-          POSTGRES_HOST: localhost
-          POSTGRES_PORT: 5432
+          DB_URL: postgresql://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install Requirements
-        run: pip install -r requirements.txt
+        run: pip install -r requirements/dev.txt
       - name: Tests
         run: python -m pytest tests/e2e.py
         # Environment variables used by the `pg_client.py`

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,0 +1,36 @@
+name: End to End Test
+on: push
+
+jobs:
+  db-job:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+        # Copy repo contents into container (needed to populate DB)
+        volumes:
+          - ${{ github.workspace }}:/repo
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Requirements
+        run: pip install -r requirements.txt
+      - name: Tests
+        run: python -m pytest tests/e2e.py
+        # Environment variables used by the `pg_client.py`
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Environment files
 .env
+
+# Python cache files
 __pycache__/
-.idea
+
+# IDE files
+.idea/
+
+# Pytest cache files
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 # Environment files
 .env
 
-# Python cache files
-__pycache__/
-
 # IDE files
 .idea/
 
-# Pytest cache files
+# Python cache files
+__pycache__/
 .pytest_cache/
+.mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,9 @@ check:
 	make lint
 	make types
 
+
+test:
+	python -m pytest tests/
+
 run:
 	python -m src.main

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ mypy-extensions
 pandas-stubs
 sqlalchemy-stubs
 pre-commit
+pytest

--- a/src/main.py
+++ b/src/main.py
@@ -9,8 +9,8 @@ from pandas import DataFrame
 from sqlalchemy import create_engine
 
 from src.config import Env, RuntimeConfig
-from src.mappings import DUNE_TO_PG
 from src.logger import log
+from src.mappings import DUNE_TO_PG
 
 DataTypes = dict[str, Any]
 

--- a/tests/db_util.py
+++ b/tests/db_util.py
@@ -1,6 +1,7 @@
 from typing import Any
-from sqlalchemy import text
+
 import sqlalchemy
+from sqlalchemy import text
 
 
 def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str, Any]]:

--- a/tests/db_util.py
+++ b/tests/db_util.py
@@ -1,0 +1,25 @@
+from typing import Any
+from sqlalchemy import text
+import sqlalchemy
+
+
+def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str, Any]]:
+    with engine.connect() as connection:
+        result = connection.execute(text(query_str))
+        rows = result.fetchall()
+
+    return [
+        {
+            # key: (bytes(value) if isinstance(value, memoryview) else value)
+            key: (f"0x{value.hex()}" if isinstance(value, memoryview) else value)
+            for key, value in zip(result.keys(), row)
+        }
+        for row in rows
+    ]
+
+
+# def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str, Any]]:
+#     with engine.connect() as connection:
+#         result = connection.execute(text(query_str))
+#         rows = result.fetchall()
+#     return [dict(zip(result.keys(), row)) for row in rows]

--- a/tests/db_util.py
+++ b/tests/db_util.py
@@ -10,16 +10,9 @@ def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str,
 
     return [
         {
-            # key: (bytes(value) if isinstance(value, memoryview) else value)
+            # Convert memoryview to hex strings: could also use bytes(value)
             key: (f"0x{value.hex()}" if isinstance(value, memoryview) else value)
             for key, value in zip(result.keys(), row)
         }
         for row in rows
     ]
-
-
-# def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str, Any]]:
-#     with engine.connect() as connection:
-#         result = connection.execute(text(query_str))
-#         rows = result.fetchall()
-#     return [dict(zip(result.keys(), row)) for row in rows]

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -1,0 +1,117 @@
+import unittest
+import datetime
+
+import pandas.testing
+
+from dune_client.models import ResultsResponse
+from sqlalchemy import create_engine
+from pandas import DataFrame
+
+from src.main import save_to_postgres, dune_result_to_df
+from tests.db_util import query_pg
+from sqlalchemy import BIGINT, BOOLEAN, VARCHAR, DATE, TIMESTAMP
+from sqlalchemy.dialects.postgresql import BYTEA
+
+DB_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
+
+SAMPLE_DUNE_RESULTS = ResultsResponse.from_dict(
+    {
+        "execution_id": "01JB4JWVAFBX4ZDSW79JNGZ99X",
+        "query_id": 4159712,
+        "is_execution_finished": True,
+        "state": "QUERY_STATE_COMPLETED",
+        "submitted_at": "2024-10-26T14:15:16.048132Z",
+        "expires_at": "2025-01-24T14:15:16.545402Z",
+        "execution_started_at": "2024-10-26T14:15:16.400388Z",
+        "execution_ended_at": "2024-10-26T14:15:16.5454Z",
+        "result": {
+            "rows": [
+                {
+                    "block_date": "2024-09-28",
+                    "block_number": 20849352,
+                    "block_time": "2024-09-28 13:12:11.000 UTC",
+                    "hash": "0x5f0b3f5d3f15bf9943b1b6c77f69",
+                    "success": True,
+                    "type": "DynamicFee",
+                }
+            ],
+            "metadata": {
+                "column_names": [
+                    "block_time",
+                    "block_number",
+                    "success",
+                    "hash",
+                    "type",
+                    "block_date",
+                ],
+                "column_types": [
+                    "timestamp with time zone",
+                    "bigint",
+                    "boolean",
+                    "varbinary",
+                    "varchar",
+                    "date",
+                ],
+                "row_count": 1,
+                "result_set_bytes": 97,
+                "total_row_count": 1,
+                "total_result_set_bytes": 97,
+                "datapoint_count": 6,
+                "pending_time_millis": 352,
+                "execution_time_millis": 145,
+            },
+        },
+    }
+)
+
+
+class TestEndToEnd(unittest.TestCase):
+    def test_dune_results_to_db(self):
+
+        engine = create_engine(DB_URL)
+        df, types = dune_result_to_df(SAMPLE_DUNE_RESULTS.result)
+
+        expected = DataFrame(
+            {
+                "block_date": ["2024-09-28"],
+                "block_number": [20849352],
+                "block_time": ["2024-09-28 13:12:11.000 UTC"],
+                "hash": [b"_\x0b?]?\x15\xbf\x99C\xb1\xb6\xc7\x7fi"],
+                "success": [True],
+                "type": ["DynamicFee"],
+            }
+        )
+        self.assertIsNone(
+            pandas.testing.assert_frame_equal(df, expected, check_dtype=True)
+        )
+        self.assertEqual(
+            types,
+            {
+                "block_date": DATE,
+                "block_number": BIGINT,
+                "block_time": TIMESTAMP,
+                "hash": BYTEA,
+                "success": BOOLEAN,
+                "type": VARCHAR,
+            },
+        )
+
+        save_to_postgres(engine, "test_table", df, types)
+
+        self.assertEqual(
+            query_pg(engine, "select * from test_table"),
+            [
+                {
+                    "block_date": datetime.date(2024, 9, 28),
+                    "block_number": 20849352,
+                    "block_time": datetime.datetime(2024, 9, 28, 13, 12, 11),
+                    "hash": "0x5f0b3f5d3f15bf9943b1b6c77f69",
+                    "success": True,
+                    "type": "DynamicFee",
+                }
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1,18 +1,18 @@
-import unittest
 import datetime
+import unittest
+from os import getenv
 
 import pandas.testing
-
 from dune_client.models import ResultsResponse
-from sqlalchemy import create_engine
 from pandas import DataFrame
+from sqlalchemy import BIGINT, BOOLEAN, VARCHAR, DATE, TIMESTAMP
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import BYTEA
 
 from src.main import save_to_postgres, dune_result_to_df
 from tests.db_util import query_pg
-from sqlalchemy import BIGINT, BOOLEAN, VARCHAR, DATE, TIMESTAMP
-from sqlalchemy.dialects.postgresql import BYTEA
 
-DB_URL = "postgresql://postgres:postgres@localhost:5432/postgres"
+DB_URL = getenv("DB_URL", "postgresql://postgres:postgres@localhost:5432/postgres")
 
 SAMPLE_DUNE_RESULTS = ResultsResponse.from_dict(
     {
@@ -111,7 +111,3 @@ class TestEndToEnd(unittest.TestCase):
                 }
             ],
         )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
We take the results from this query execution:

```sh
curl -X GET https://api.dune.com/api/v1/query/4159712/results -H "x-dune-api-key: $DUNE_API_KEY" | jq
```

and pass it through the full flow. After, we also read the date from Postgres and confirm it was stored as expected.