### PR TITLE
Minor Cleanup Naming & Imports

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import yaml
 from dotenv import load_dotenv
-from dune_client.types import ParameterType, QueryParameter
 from dune_client.query import QueryBase
+from dune_client.types import ParameterType, QueryParameter
 
 from src.destinations.dune import DuneDestination
 from src.destinations.postgres import PostgresDestination
 from src.interfaces import Destination, Source
-from src.jobs import BaseJob, Database
+from src.job import Job, Database
 from src.sources.dune import DuneSource
 from src.sources.postgres import PostgresSource
 
@@ -78,12 +78,10 @@ def parse_query_parameters(params: list[dict[str, Any]]) -> list[QueryParameter]
 class RuntimeConfig:
     """A class to represent the runtime configuration settings."""
 
-    jobs: list[BaseJob]
+    jobs: list[Job]
 
     @classmethod
-    def load_from_yaml(
-        cls, file_path: Union[Path, str] = "config.yaml"
-    ) -> RuntimeConfig:
+    def load_from_yaml(cls, file_path: Path | str = "config.yaml") -> RuntimeConfig:
         with open(file_path, "rb") as _handle:
             data = yaml.safe_load(_handle)
 
@@ -93,7 +91,7 @@ class RuntimeConfig:
         for job_config in data.get("jobs", []):
             source = cls._build_source(env, job_config["source"])
             destination = cls._build_destination(env, job_config["destination"])
-            jobs.append(BaseJob(source, destination))
+            jobs.append(Job(source, destination))
 
         return cls(jobs=jobs)
 

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -1,9 +1,12 @@
+from typing import Literal
+
 import sqlalchemy
 from sqlalchemy import create_engine
 
-from src.interfaces import Destination
-from src.sync_types import TableExistsPolicy, TypedDataFrame
+from src.interfaces import Destination, TypedDataFrame
 from src.logger import log
+
+TableExistsPolicy = Literal["append", "replace"]
 
 
 class PostgresDestination(Destination[TypedDataFrame]):

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -1,5 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import Any
 from typing import TypeVar, Generic
+
+from pandas import DataFrame
+
+TypedDataFrame = tuple[DataFrame, dict[str, Any]]
 
 # This will represent your data type (DataFrame, dict, etc.)
 T = TypeVar("T")

--- a/src/job.py
+++ b/src/job.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -22,7 +23,7 @@ class Database(Enum):
 
 
 @dataclass
-class BaseJob:
+class Job:
     """Base class for all jobs with common attributes"""
 
     source: Source[Any]

--- a/src/main.py
+++ b/src/main.py
@@ -2,17 +2,13 @@
 from pathlib import Path
 
 import src as root
-from src.config import Env, RuntimeConfig
+from src.config import RuntimeConfig
 from src.logger import log
-
-env = Env.load()
 
 
 def main() -> None:
     root_path = Path(root.__path__[0])
-    config = RuntimeConfig.load_from_yaml(
-        str((root_path.parent / "config.yaml").absolute())
-    )
+    config = RuntimeConfig.load_from_yaml((root_path.parent / "config.yaml").absolute())
     # TODO: Async job execution https://github.com/bh2smith/dune-sync/issues/20
     for job in config.jobs:
         job.run()

--- a/src/sources/dune.py
+++ b/src/sources/dune.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Type, Any
+from typing import Type, Any, Literal
 
 import pandas as pd
 from dune_client.client import DuneClient
@@ -9,8 +9,7 @@ from pandas import DataFrame
 from sqlalchemy import BIGINT, BOOLEAN, VARCHAR, DATE, TIMESTAMP
 from sqlalchemy.dialects.postgresql import BYTEA, DOUBLE_PRECISION
 
-from src.interfaces import Source
-from src.sync_types import TypedDataFrame, DuneQueryEngine
+from src.interfaces import Source, TypedDataFrame
 
 DUNE_TO_PG: dict[str, Type[Any]] = {
     "bigint": BIGINT,
@@ -65,7 +64,7 @@ class DuneSource(Source[TypedDataFrame], ABC):
         api_key: str,
         query: QueryBase,
         poll_frequency: int = 1,
-        query_engine: DuneQueryEngine = "medium",
+        query_engine: Literal["medium", "large"] = "medium",
     ) -> None:
         self.query = query
         self.poll_frequency = poll_frequency

--- a/src/sync_types.py
+++ b/src/sync_types.py
@@ -1,8 +1,0 @@
-from typing import Any, Literal
-
-from pandas import DataFrame
-
-TypedDataFrame = tuple[DataFrame, dict[str, Any]]
-
-TableExistsPolicy = Literal["append", "replace"]
-DuneQueryEngine = Literal["medium", "large"]


### PR DESCRIPTION
1. Many of the declared types are only used in one place (removed).
2. Delete sync type, putting the one entry into `interfaces.py`.
3. Rename `BaseJob` as `Job` because there is only one Job.