### PR TITLE
Validate & Test

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,2 @@
 [MASTER]
-disable=fixme,missing-function-docstring,missing-module-docstring
+disable=fixme,missing-function-docstring,missing-module-docstring,too-few-public-methods

--- a/src/destinations/dune.py
+++ b/src/destinations/dune.py
@@ -22,6 +22,7 @@ class DuneDestination(Destination[DataFrame]):
     def __init__(self, api_key: str, table_name: str):
         self.client = DuneClient(api_key)
         self.table_name: str = table_name
+        super().__init__()
 
     def validate(self) -> bool:
         # Nothing I can think of to validate here...

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -27,6 +27,7 @@ class PostgresDestination(Destination[TypedDataFrame]):
         self.engine: sqlalchemy.engine.Engine = create_engine(db_url)
         self.table_name: str = table_name
         self.if_exists: TableExistsPolicy = if_exists
+        super().__init__()
 
     def validate(self) -> bool:
         # Nothing I can think of to validate here...

--- a/src/interfaces.py
+++ b/src/interfaces.py
@@ -10,7 +10,19 @@ TypedDataFrame = tuple[DataFrame, dict[str, Any]]
 T = TypeVar("T")
 
 
-class Source(ABC, Generic[T]):
+class Validate(ABC):
+    """Enforces validation on inheriting classes"""
+
+    def __init__(self) -> None:
+        if not self.validate():
+            raise ValueError(f"Config for {self.__class__.__name__} is invalid")
+
+    @abstractmethod
+    def validate(self) -> bool:
+        """Validate the configuration"""
+
+
+class Source(Validate, Generic[T]):
     """Abstract base class for data sources"""
 
     @abstractmethod
@@ -18,21 +30,13 @@ class Source(ABC, Generic[T]):
         """Fetch data from the source"""
 
     @abstractmethod
-    def validate(self) -> bool:
-        """Validate the source configuration"""
-
-    @abstractmethod
     def is_empty(self, data: T) -> bool:
         """Return True if the fetched data is empty"""
 
 
-class Destination(ABC, Generic[T]):
+class Destination(Validate, Generic[T]):
     """Abstract base class for data destinations"""
 
     @abstractmethod
     def save(self, data: T) -> None:
         """Save data to the destination"""
-
-    @abstractmethod
-    def validate(self) -> bool:
-        """Validate the destination configuration"""

--- a/src/sources/dune.py
+++ b/src/sources/dune.py
@@ -70,6 +70,7 @@ class DuneSource(Source[TypedDataFrame], ABC):
         self.query = query
         self.poll_frequency = poll_frequency
         self.client = DuneClient(api_key, performance=query_engine)
+        super().__init__()
 
     def validate(self) -> bool:
         # Nothing I can think of to validate here...

--- a/src/sources/postgres.py
+++ b/src/sources/postgres.py
@@ -36,7 +36,7 @@ class PostgresSource(Source[DataFrame]):
         self.engine: sqlalchemy.engine.Engine = create_engine(db_url)
         self.query_string = ""
         self._set_query_string(query_string)
-        self.validate()
+        super().__init__()
 
     def validate(self) -> bool:
         try:

--- a/tests/fixtures/config/basic.yaml
+++ b/tests/fixtures/config/basic.yaml
@@ -26,7 +26,7 @@ jobs:
       ref: postgres
       table_name: foo_table
       if_exists: append
-      query_string: SELECT * FROM foo;
+      query_string: SELECT 1;
     destination:
       ref: dune
       table_name: table_name

--- a/tests/unit/sources_test.py
+++ b/tests/unit/sources_test.py
@@ -9,7 +9,7 @@ from sqlalchemy.dialects.postgresql import BYTEA
 
 from src.config import RuntimeConfig
 from src.sources.dune import _reformat_varbinary_columns, dune_result_to_df
-from src.sources.postgres import _convert_bytea_to_hex
+from src.sources.postgres import PostgresSource, _convert_bytea_to_hex
 from tests import fixtures_root, config_root
 
 
@@ -70,14 +70,21 @@ class TestSourceUtils(unittest.TestCase):
 
 class TestPostgresSource(unittest.TestCase):
 
-    @patch.dict(
-        os.environ,
-        {
-            "DUNE_API_KEY": "test_key",
-            "DB_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
-        },
-        clear=True,
-    )
+    @classmethod
+    def setUpClass(cls):
+        cls.env_patcher = patch.dict(
+            os.environ,
+            {
+                "DUNE_API_KEY": "test_key",
+                "DB_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
+            },
+            clear=True,
+        )
+        cls.env_patcher.start()
+
+    # TODO: This test is a Config loader test not directly testing PostgresSource
+    #  When changing it to call PGSource directly, yields a bug with the constructor.
+    #  The constructor only accepts string input, not Path!
     def test_load_sql_file(self):
         os.chdir(fixtures_root)
 
@@ -88,3 +95,11 @@ class TestPostgresSource(unittest.TestCase):
         missing_file.unlink(missing_ok=True)
         with self.assertRaises(RuntimeError):
             RuntimeConfig.load_from_yaml(config_root / "invalid_sql_file.yaml")
+
+    def test_invalid_pg_source(self):
+        with self.assertRaises(ValueError) as context:
+            PostgresSource(
+                db_url=os.environ["DB_URL"],
+                query_string="SELECT * FROM does_not_exist",
+            )
+        self.assertEqual("Config for PostgresSource is invalid", str(context.exception))


### PR DESCRIPTION
This imposes validation at construction by calling the super init. Its not my favourite solution because users have to call super after. However, the type check enforces that super is called and if someone accidentally puts it before, it will likely fail (at least whenever the validate method isn't vacuously true). 

Added a test that the constructor raises on invalid input.