### PR TITLE
Redirect Non-Error Logs to stdout

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -10,7 +10,7 @@ class InfoFilter(logging.Filter):
 
     def filter(self, record):
         """Return True if we should log this record."""
-        return record.levelno in (logging.INFO, logging.WARNING)
+        return record.levelno not in (logging.ERROR, logging.CRITICAL)
 
 
 # Create handlers for stdout and stderr

--- a/src/logger.py
+++ b/src/logger.py
@@ -23,8 +23,8 @@ stderr_handler.setLevel(logging.ERROR)
 
 # Configure log formatter
 formatter = logging.Formatter(
-    fmt='%(asctime)s [%(levelname)s] %(name)s:%(module)s.%(funcName)s:%(lineno)d - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    fmt="%(asctime)s [%(levelname)s] %(name)s:%(module)s.%(funcName)s:%(lineno)d - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 stdout_handler.setFormatter(formatter)
 stderr_handler.setFormatter(formatter)
@@ -33,7 +33,7 @@ stderr_handler.setFormatter(formatter)
 logging.basicConfig(
     level=getenv("LOG_LEVEL", "INFO"),
     handlers=[stdout_handler, stderr_handler],
-    force=True  # Ensure we override any existing configuration
+    force=True,  # Ensure we override any existing configuration
 )
 
 log = logging.getLogger("dune-sync")

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,9 +1,39 @@
 """Logging configuration for the dune-sync package."""
 
 import logging
+import sys
 from os import getenv
 
-# TODO maybe support custom logging config loaded from the config file
-logging.basicConfig(level=getenv("LOG_LEVEL", "INFO"))
+
+class InfoFilter(logging.Filter):
+    """Filter that only allows records at INFO or WARNING level."""
+
+    def filter(self, record):
+        """Return True if we should log this record."""
+        return record.levelno in (logging.INFO, logging.WARNING)
+
+
+# Create handlers for stdout and stderr
+stdout_handler = logging.StreamHandler(sys.stdout)
+stderr_handler = logging.StreamHandler(sys.stderr)
+
+# Add filters
+stdout_handler.addFilter(InfoFilter())
+stderr_handler.setLevel(logging.ERROR)
+
+# Configure log formatter
+formatter = logging.Formatter(
+    fmt='%(asctime)s [%(levelname)s] %(name)s:%(module)s.%(funcName)s:%(lineno)d - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+stdout_handler.setFormatter(formatter)
+stderr_handler.setFormatter(formatter)
+
+# Basic config
+logging.basicConfig(
+    level=getenv("LOG_LEVEL", "INFO"),
+    handlers=[stdout_handler, stderr_handler],
+    force=True  # Ensure we override any existing configuration
+)
 
 log = logging.getLogger("dune-sync")

--- a/src/logger.py
+++ b/src/logger.py
@@ -8,7 +8,7 @@ from os import getenv
 class InfoFilter(logging.Filter):
     """Filter that only allows records at INFO or WARNING level."""
 
-    def filter(self, record):
+    def filter(self, record: logging.LogRecord) -> bool:
         """Return True if we should log this record."""
         return record.levelno not in (logging.ERROR, logging.CRITICAL)
 
@@ -23,7 +23,10 @@ stderr_handler.setLevel(logging.ERROR)
 
 # Configure log formatter
 formatter = logging.Formatter(
-    fmt="%(asctime)s [%(levelname)s] %(name)s:%(module)s.%(funcName)s:%(lineno)d - %(message)s",
+    fmt=(
+        "%(asctime)s [%(levelname)s] %(name)s:%(module)s."
+        "%(funcName)s:%(lineno)d - %(message)s"
+    ),
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 stdout_handler.setFormatter(formatter)


### PR DESCRIPTION
Closes #89 

Taking the advice from the issue and redefining logs. We also add a more detailed log format. 


### Test Plan

```sh
docker-compose up -d
make run
```

Produces the following logs:

<details><summary>Log Sample</summary>

```
2024-11-25 13:15:08 [INFO] dune_client.api.base:client_async.execute:212 - executing 4238114 on medium cluster
2024-11-25 13:15:08 [INFO] dune_client.api.base:client_async.execute:212 - executing 4273244 on medium cluster
2024-11-25 13:15:09 [INFO] dune-sync:main.main:66 - Job completed: Sync Parameterized Dune Query with Multiple Types to Postgres
2024-11-25 13:15:09 [INFO] dune_client.api.base:client_async._refresh:585 - waiting for query execution 01JDHKYFHN0YMH81B3D1B3RJ1T to complete: ExecutionState.PENDING (queue position: 1)
2024-11-25 13:15:09 [INFO] dune_client.api.base:client_async._refresh:585 - waiting for query execution 01JDHKYFHR198HJ5YD7PZJZDNK to complete: ExecutionState.PENDING (queue position: 2)
2024-11-25 13:15:14 [WARNING] dune-sync:dune._handle_column_types:128 - Unknown column: row(appcode varchar, appdataparams row(appcode varchar, environment varchar), backend row(hooks row(post array(row(calldata varchar, gaslimit varchar, target varchar)), pre array(row(calldata varchar, gaslimit varchar, target varchar)))), environment varchar, fullappdata varchar, metadata row(environment varchar, hooks row(post array(row(calldata varchar, gaslimit varchar, target varchar)), pre array(row(calldata varchar, gaslimit varchar, target varchar)), version varchar), orderclass row(orderclass varchar, version varchar), partnerfee row(bps bigint, recipient varchar), quote row(buyamount varchar, sellamount varchar, slippagebips varchar, version varchar), referrer row(address varchar, kind varchar, referrer varchar, version varchar), utm row(utmcampaign varchar, utmcontent varchar, utmmedium varchar, utmsource varchar, utmterm varchar, version varchar), widget row(appcode varchar, environment varchar)), metadataparams row(orderclassparams row(orderclass varchar), quoteparams row(slippagebips varchar), utmparams row(utmsource varchar)), version varchar) - treating as JSONB
2024-11-25 13:15:14 [INFO] dune-sync:postgres.save:91 - Data saved to app_data successfully!
2024-11-25 13:15:14 [INFO] dune-sync:main.main:66 - Job completed: Table Independent Query to Dune
2024-11-25 13:15:14 [WARNING] dune-sync:dune._handle_column_types:128 - Unknown column: array(row(address varbinary, storagekeys array(varbinary))) - treating as JSONB
2024-11-25 13:15:15 [INFO] dune-sync:postgres.save:91 - Data saved to results_4238114 successfully!
2024-11-25 13:15:15 [INFO] dune-sync:main.main:66 - Job completed: Sync Parameterized Dune Query with Multiple Types to Postgres
```
</details> 