### PR TITLE
Upsert aka On Conflict Do Update

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Requirements
         run: POETRY_VIRTUALENVS_CREATE=false python -m poetry install
       - name: Run tests with coverage
-        run: pytest --cov=src --cov-report=xml --cov-fail-under=80
+        run: pytest --cov=src --cov-report=xml --cov-fail-under=90
         # Environment variables used by the `pg_client.py`
         env:
           DB_URL: postgresql://postgres:postgres@localhost:5432/postgres

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ fmt:
 
 lint:
 	ruff check .
+	pylint src/
 
 types:
 	mypy ${PROJECT_ROOT}/ --strict

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,9 @@ jobs:
     destination:
       ref: PG
       table_name: results_4238114
-      if_exists: replace
+      if_exists: upsert
+      conflict_columns:
+        - hash
 
   - name: Table Independent Query to Dune
     source:

--- a/config.yaml
+++ b/config.yaml
@@ -27,7 +27,7 @@ jobs:
       ref: PG
       table_name: results_4238114
       if_exists: upsert
-      conflict_columns:
+      index_columns:
         - hash
 
   - name: Table Independent Query to Dune

--- a/src/config.py
+++ b/src/config.py
@@ -295,6 +295,6 @@ class RuntimeConfig:
                     db_url=dest.key,
                     table_name=dest_config["table_name"],
                     if_exists=dest_config["if_exists"],
-                    conflict_columns=dest_config.get("conflict_columns", []),
+                    index_columns=dest_config.get("index_columns", []),
                 )
         raise ValueError(f"Unsupported destination_db type: {dest}")

--- a/src/config.py
+++ b/src/config.py
@@ -295,5 +295,6 @@ class RuntimeConfig:
                     db_url=dest.key,
                     table_name=dest_config["table_name"],
                     if_exists=dest_config["if_exists"],
+                    conflict_columns=dest_config.get("conflict_columns", []),
                 )
         raise ValueError(f"Unsupported destination_db type: {dest}")

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import text
 from src.interfaces import Destination, TypedDataFrame
 from src.logger import log
 
-TableExistsPolicy = Literal["append", "replace", "upsert", "fail"]
+TableExistsPolicy = Literal["append", "replace", "upsert"]
 
 
 class PostgresDestination(Destination[TypedDataFrame]):

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -203,10 +203,6 @@ class PostgresDestination(Destination[TypedDataFrame]):
         # Convert the DataFrame to a list of dictionaries for SQLAlchemy to use
         records = df.to_dict(orient="records")
 
-        # Debugging: Print statement for confirmation
-        print("Insert Statement:\n", insert_stmt)
-        print("Records:\n", records)
-
         # Execute the upsert
         with self.engine.connect() as conn:
             with conn.begin():

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -3,12 +3,13 @@
 from typing import Literal
 
 import sqlalchemy
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.sql import text
 
 from src.interfaces import Destination, TypedDataFrame
 from src.logger import log
 
-TableExistsPolicy = Literal["append", "replace"]
+TableExistsPolicy = Literal["append", "replace", "upsert", "fail"]
 
 
 class PostgresDestination(Destination[TypedDataFrame]):
@@ -25,7 +26,7 @@ class PostgresDestination(Destination[TypedDataFrame]):
         The name of the destination table in PostgreSQL where data will be saved.
     if_exists : TableExistsPolicy
         Policy for handling existing tables:
-            "fail", "replace", or "append" (default is "append").
+            "replace", "append", "upsert" (default is "append").
 
     Methods
     -------
@@ -42,18 +43,61 @@ class PostgresDestination(Destination[TypedDataFrame]):
         db_url: str,
         table_name: str,
         if_exists: TableExistsPolicy = "append",
+        conflict_columns: list[str] | None = None,
     ):
+        if conflict_columns is None:
+            conflict_columns = []
         self.engine: sqlalchemy.engine.Engine = create_engine(db_url)
         self.table_name: str = table_name
         self.if_exists: TableExistsPolicy = if_exists
+        # List of column forming the ON CONFLICT condition.
+        # Only relevant for "upsert" TableExistsPolicy
+        self.conflict_columns: list[str] = conflict_columns
+
         super().__init__()
 
     def validate(self) -> bool:
-        """Validate the destination setup.
-
-        (currently a placeholder that returns True).
-        """
+        """Validate the destination setup."""
+        if self.if_exists == "upsert" and len(self.conflict_columns) == 0:
+            log.error("Postgres Destination can't upsert without conflict columns.")
+            return False
         return True
+
+    def validate_unique_constraints(self) -> None:
+        """Validate table has unique or exclusion constraint for conflict columns."""
+        inspector = inspect(self.engine)
+        constraints = inspector.get_unique_constraints(self.table_name)
+        conflict_columns_set = set(self.conflict_columns)
+
+        for constraint in constraints:
+            if conflict_columns_set == set(constraint["column_names"]):
+                return  # Found a matching unique constraint!
+
+        table, columns = self.table_name, self.conflict_columns
+        conflict_columns_str = ", ".join(columns)
+        constraint_name = f"{self.table_name}_{'_'.join(columns)}_unique"
+        suggestion = (
+            f"ALTER TABLE {table} ADD CONSTRAINT "
+            f"{constraint_name} UNIQUE ({conflict_columns_str});"
+        )
+        message = (
+            f"The ON CONFLICT clause requires a unique or exclusion constraint "
+            f"on the column(s): {conflict_columns_str}. "
+            f"Please ensure the table '{table}' has the necessary constraint. "
+            f"To fix this, you can run the following SQL command:\n{suggestion}"
+        )
+        # Log or print the error message
+        log.error(message)
+        raise ValueError("No unique or exclusion constraint found. See error logs.")
+
+    def table_exists(self) -> bool:
+        """Check if a table exists in the database.
+
+        :return: True if the table exists, False otherwise.
+        """
+        inspector = inspect(self.engine)
+        tables = inspector.get_table_names()
+        return self.table_name in tables
 
     def save(
         self,
@@ -75,17 +119,90 @@ class PostgresDestination(Destination[TypedDataFrame]):
             If the DataFrame is empty, a warning is logged, and no data is saved.
 
         """
-        df, dtypes = data
+        df, _ = data
         if df.empty:
             log.warning("DataFrame is empty. Skipping save to PostgreSQL.")
             return
+        match self.if_exists:
+            case "upsert":
+                self.upsert(data)
+            case "append":
+                self.append(data)
+            case "replace":
+                self.replace(data)
+            case _:
+                raise ValueError(f"Invalid if_exists policy: {self.if_exists}")
+        log.info("Data saved to %s successfully!", self.table_name)
 
+    def replace(
+        self,
+        data: TypedDataFrame,
+    ) -> None:
+        """Replace the table with the provided data."""
+        df, dtypes = data
         with self.engine.connect() as connection:
             df.to_sql(
                 self.table_name,
                 connection,
-                if_exists=self.if_exists,
+                if_exists="replace",
                 index=False,
                 dtype=dtypes,
             )
-        log.info("Data saved to %s successfully!", self.table_name)
+
+    def append(
+        self,
+        data: TypedDataFrame,
+    ) -> None:
+        """Append data to the table."""
+        df, dtypes = data
+        with self.engine.connect() as connection:
+            df.to_sql(
+                self.table_name,
+                connection,
+                if_exists="append",
+                index=False,
+                dtype=dtypes,
+            )
+
+    def upsert(self, data: TypedDataFrame) -> None:
+        """Upsert data from a DataFrame into a SQL table.
+
+        :param data: Typed pandas DataFrame containing the data to upsert.
+        """
+        if not self.table_exists():
+            # Do append.
+            self.append(data)
+            return
+
+        self.validate_unique_constraints()
+        df, _ = data
+        # Get all column names from the DataFrame
+        columns = df.columns.tolist()
+
+        # Generate the column list for the INSERT clause
+        column_list = ", ".join(columns)
+
+        # Generate the parameterized values for the INSERT clause
+        value_placeholders = ", ".join(f":{col}" for col in columns)
+
+        # Generate the update assignments for the ON CONFLICT clause
+        update_assignments = ", ".join(
+            f"{col} = EXCLUDED.{col}"
+            for col in columns
+            if col not in self.conflict_columns
+        )
+
+        # Define the insert statement with an ON CONFLICT clause
+        insert_stmt = f"""
+        INSERT INTO {self.table_name} ({column_list})
+        VALUES ({value_placeholders})
+        ON CONFLICT ({', '.join(self.conflict_columns)}) DO UPDATE SET
+            {update_assignments};
+        """
+
+        # Convert the DataFrame to a list of dictionaries for SQLAlchemy to use
+        records = df.to_dict(orient="records")
+
+        # Execute the upsert
+        with self.engine.connect() as conn:
+            conn.execute(text(insert_stmt), records)

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -59,7 +59,7 @@ class PostgresDestination(Destination[TypedDataFrame]):
     def validate(self) -> bool:
         """Validate the destination setup."""
         if self.if_exists == "upsert" and len(self.conflict_columns) == 0:
-            log.error("Postgres Destination can't upsert without conflict columns.")
+            log.error("Upsert without conflict columns.")
             return False
         return True
 

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -3,8 +3,8 @@
 from typing import Literal
 
 import sqlalchemy
-from sqlalchemy import create_engine, inspect
-from sqlalchemy.sql import text
+from sqlalchemy import MetaData, Table, create_engine, inspect
+from sqlalchemy.dialects.postgresql import insert
 
 from src.interfaces import Destination, TypedDataFrame
 from src.logger import log
@@ -43,46 +43,46 @@ class PostgresDestination(Destination[TypedDataFrame]):
         db_url: str,
         table_name: str,
         if_exists: TableExistsPolicy = "append",
-        conflict_columns: list[str] | None = None,
+        index_columns: list[str] | None = None,
     ):
-        if conflict_columns is None:
-            conflict_columns = []
+        if index_columns is None:
+            index_columns = []
         self.engine: sqlalchemy.engine.Engine = create_engine(db_url)
         self.table_name: str = table_name
         self.if_exists: TableExistsPolicy = if_exists
         # List of column forming the ON CONFLICT condition.
         # Only relevant for "upsert" TableExistsPolicy
-        self.conflict_columns: list[str] = conflict_columns
+        self.index_columns: list[str] = index_columns
 
         super().__init__()
 
     def validate(self) -> bool:
         """Validate the destination setup."""
-        if self.if_exists == "upsert" and len(self.conflict_columns) == 0:
-            log.error("Upsert without conflict columns.")
+        if self.if_exists == "upsert" and len(self.index_columns) == 0:
+            log.error("Upsert without index columns.")
             return False
         return True
 
     def validate_unique_constraints(self) -> None:
-        """Validate table has unique or exclusion constraint for conflict columns."""
+        """Validate table has unique or exclusion constraint for index columns."""
         inspector = inspect(self.engine)
         constraints = inspector.get_unique_constraints(self.table_name)
-        conflict_columns_set = set(self.conflict_columns)
+        index_columns_set = set(self.index_columns)
 
         for constraint in constraints:
-            if conflict_columns_set == set(constraint["column_names"]):
+            if index_columns_set == set(constraint["column_names"]):
                 return  # Found a matching unique constraint!
 
-        table, columns = self.table_name, self.conflict_columns
-        conflict_columns_str = ", ".join(columns)
+        table, columns = self.table_name, self.index_columns
+        index_columns_str = ", ".join(columns)
         constraint_name = f"{self.table_name}_{'_'.join(columns)}_unique"
         suggestion = (
             f"ALTER TABLE {table} ADD CONSTRAINT "
-            f"{constraint_name} UNIQUE ({conflict_columns_str});"
+            f"{constraint_name} UNIQUE ({index_columns_str});"
         )
         message = (
-            f"The ON CONFLICT clause requires a unique or exclusion constraint "
-            f"on the column(s): {conflict_columns_str}. "
+            "The ON CONFLICT clause requires a unique or exclusion constraint "
+            f"on the column(s): {index_columns_str}. "
             f"Please ensure the table '{table}' has the necessary constraint. "
             f"To fix this, you can run the following SQL command:\n{suggestion}"
         )
@@ -179,31 +179,15 @@ class PostgresDestination(Destination[TypedDataFrame]):
         # Get all column names from the DataFrame
         columns = df.columns.tolist()
 
-        # Generate the column list for the INSERT clause
-        column_list = ", ".join(columns)
+        metadata = MetaData()
+        table = Table(self.table_name, metadata, autoload_with=self.engine)
+        statement = insert(table).values(**{col: df[col] for col in columns})
 
-        # Generate the parameterized values for the INSERT clause
-        value_placeholders = ", ".join(f":{col}" for col in columns)
-
-        # Generate the update assignments for the ON CONFLICT clause
-        update_assignments = ", ".join(
-            f"{col} = EXCLUDED.{col}"
-            for col in columns
-            if col not in self.conflict_columns
+        statement = statement.on_conflict_do_update(
+            index_elements=self.index_columns,
+            set_={col: getattr(statement.excluded, col) for col in columns},
         )
-
-        # Define the insert statement with an ON CONFLICT clause
-        insert_stmt = f"""
-        INSERT INTO {self.table_name} ({column_list})
-        VALUES ({value_placeholders})
-        ON CONFLICT ({', '.join(self.conflict_columns)}) DO UPDATE SET
-            {update_assignments};
-        """
-
-        # Convert the DataFrame to a list of dictionaries for SQLAlchemy to use
         records = df.to_dict(orient="records")
-
-        # Execute the upsert
         with self.engine.connect() as conn:
             with conn.begin():
-                conn.execute(text(insert_stmt), records)
+                conn.execute(statement, records)

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -203,6 +203,11 @@ class PostgresDestination(Destination[TypedDataFrame]):
         # Convert the DataFrame to a list of dictionaries for SQLAlchemy to use
         records = df.to_dict(orient="records")
 
+        # Debugging: Print statement for confirmation
+        print("Insert Statement:\n", insert_stmt)
+        print("Records:\n", records)
+
         # Execute the upsert
         with self.engine.connect() as conn:
-            conn.execute(text(insert_stmt), records)
+            with conn.begin():
+                conn.execute(text(insert_stmt), records)

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,7 @@ from src.logger import log
 
 
 async def main() -> None:
-    """Load configuration and execute jobs asyncronously.
+    """Load configuration and execute jobs asynchronously.
 
     The function:
     1. Parses command line arguments

--- a/tests/db_util.py
+++ b/tests/db_util.py
@@ -17,3 +17,27 @@ def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str,
         }
         for row in rows
     ]
+
+
+def create_table(engine: sqlalchemy.engine.Engine, table_name: str) -> None:
+    with engine.connect() as connection:
+        # Begin a transaction explicitly for DDL
+        with connection.begin():
+            result = connection.execute(
+                text(f"CREATE TABLE IF NOT EXISTS {table_name} (id SERIAL, value TEXT);")
+            )
+            print("Table created successfully.", result)
+
+
+def drop_table(engine: sqlalchemy.engine.Engine, table_name: str) -> None:
+    with engine.connect() as connection:
+        # Begin a transaction explicitly for DDL
+        with connection.begin():
+            connection.execute(text(f"DROP TABLE IF EXISTS {table_name};"))
+
+
+def raw_exec(engine: sqlalchemy.engine.Engine, query_str: str) -> None:
+    with engine.connect() as connection:
+        # Begin a transaction explicitly for DDL
+        with connection.begin():
+            connection.execute(text(query_str))

--- a/tests/db_util.py
+++ b/tests/db_util.py
@@ -19,12 +19,31 @@ def query_pg(engine: sqlalchemy.engine.Engine, query_str: str) -> list[dict[str,
     ]
 
 
+def select_star(
+    engine: sqlalchemy.engine.Engine, table_name: str
+) -> list[dict[str, Any]]:
+    with engine.connect() as connection:
+        result = connection.execute(text(f"SELECT * FROM {table_name}"))
+        rows = result.fetchall()
+
+    return [
+        {
+            # Convert memoryview to hex strings: could also use bytes(value)
+            key: (f"0x{value.hex()}" if isinstance(value, memoryview) else value)
+            for key, value in zip(result.keys(), row, strict=False)
+        }
+        for row in rows
+    ]
+
+
 def create_table(engine: sqlalchemy.engine.Engine, table_name: str) -> None:
     with engine.connect() as connection:
         # Begin a transaction explicitly for DDL
         with connection.begin():
             result = connection.execute(
-                text(f"CREATE TABLE IF NOT EXISTS {table_name} (id SERIAL, value TEXT);")
+                text(
+                    f"CREATE TABLE IF NOT EXISTS {table_name} (id SERIAL, value TEXT);"
+                )
             )
             print("Table created successfully.", result)
 

--- a/tests/unit/destinations_test.py
+++ b/tests/unit/destinations_test.py
@@ -275,7 +275,6 @@ class PostgresDestinationTest(unittest.TestCase):
             if_exists="replace",
         )
         df1 = pd.DataFrame({"id": [1, 2], "value": ["alice", "bob"]})
-        
 
         drop_table(pg_dest.engine, table_name)
 

--- a/tests/unit/destinations_test.py
+++ b/tests/unit/destinations_test.py
@@ -266,3 +266,37 @@ class PostgresDestinationTest(unittest.TestCase):
 
         # Clean up
         drop_table(pg_dest.engine, table_name)
+
+    def test_replace(self):
+        table_name = "test_replace"
+        pg_dest = PostgresDestination(
+            db_url=self.db_url,
+            table_name=table_name,
+            if_exists="replace",
+        )
+        df1 = pd.DataFrame({"id": [1, 2], "value": ["alice", "bob"]})
+        
+
+        drop_table(pg_dest.engine, table_name)
+
+        pg_dest.replace((df1, {}))
+        self.assertEqual(
+            [
+                {"id": 1, "value": "alice"},
+                {"id": 2, "value": "bob"},
+            ],
+            select_star(pg_dest.engine, table_name),
+        )
+
+        df2 = pd.DataFrame({"id": [3, 4], "value": ["chuck", "dave"]})
+        pg_dest.replace((df2, {}))
+        self.assertEqual(
+            [
+                {"id": 3, "value": "chuck"},
+                {"id": 4, "value": "dave"},
+            ],
+            select_star(pg_dest.engine, table_name),
+        )
+
+        # Clean up
+        drop_table(pg_dest.engine, table_name)


### PR DESCRIPTION
Introducing `INSERT ... ON CONFLICT ... DO UPDATE`!

This works well but also requires primary key or, more loosely, a uniqueness constraint on the table in question. 
We have insightful error messaging that will literally print out the table alterations require for the provided `conflict_columns`:

So, when table exists without index we will see this error log suggesting how to fix the issue.
```sh
The ON CONFLICT clause requires a unique or exclusion constraint on the column(s): hash. Please ensure the table 'results_4238114' has the necessary constraint.To fix this, you can run the following SQL command:
ALTER TABLE results_4238114 ADD CONSTRAINT results_4238114_hash_unique UNIQUE (hash);
```

Note that, additionally, the table does not need to exist first. It will be created without any validation on the uniqueness constraints at first run. We only validate the uniqueness at the first time of actual upsert.

## Test Plan 

For now this is

1. Run it 
```
docker-compose up -d
make run
```
If you already have the table (from previous runs) you will hit the error above.
Execute the suggested ALTER TABLE command and try again!

**UPDATE:** 
There are now "unit" tests of all conflict column validation and upsert method works as expected.



Closes #56.