### PR TITLE
Fix: CI Coverage as xml

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Requirements
         run: POETRY_VIRTUALENVS_CREATE=false python -m poetry install
       - name: Run tests with coverage
-        run: pytest --cov=src --cov-report=html --cov-fail-under=80
+        run: pytest --cov=src --cov-report=xml --cov-fail-under=80
         # Environment variables used by the `pg_client.py`
         env:
           DB_URL: postgresql://postgres:postgres@localhost:5432/postgres


### PR DESCRIPTION
We changed the CI report to XML so all our jobs were failing to upload 

https://github.com/bh2smith/dune-sync/actions/runs/12031629720/job/33541588065?pr=93