### PR TITLE
HTML-formatted test coverage report

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Requirements
         run: POETRY_VIRTUALENVS_CREATE=false python -m poetry install
       - name: Run tests with coverage
-        run: pytest --cov=src --cov-report=xml --cov-fail-under=80
+        run: pytest --cov=src --cov-report=html --cov-fail-under=90
         # Environment variables used by the `pg_client.py`
         env:
           DB_URL: postgresql://postgres:postgres@localhost:5432/postgres
@@ -39,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
-          path: coverage.xml
+          path: htmlcov


### PR DESCRIPTION
Gets you a downloadable ZIP with the coverage report as HTML, like this one:

[coverage-report(1).zip](https://github.com/user-attachments/files/17924306/coverage-report.1.zip)
