### PR TITLE
Insert Ignore (aka on conflict do nothing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ For Dune destinations (`ref: Dune`):
 
 For Postgres destinations (`ref: Postgres`):
 - `table_name`: String. Name of table to insert/append into
-- `if_exists`: String. One of `fail`, `replace`, `append`
+- `if_exists`: String. One of `upsert`, `insert_ignore`, `replace` or `append`.
+  - `index_columns`: String[]. only relevant for `upsert` or `insert_ignore` a list of columns on which to detect conflict
 
 ### Define environment
 

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -166,39 +166,12 @@ class PostgresDestination(Destination[TypedDataFrame]):
                 dtype=dtypes,
             )
 
-    # def upsert(self, data: TypedDataFrame) -> None:
-    #     """Upsert data from a DataFrame into a SQL table.
-
-    #     :param data: Typed pandas DataFrame containing the data to upsert.
-    #     """
-    #     if not self.table_exists():
-    #         # Do append.
-    #         self.append(data)
-    #         return
-
-    #     self.validate_unique_constraints()
-    #     df, _ = data
-    #     # Get all column names from the DataFrame
-    #     columns = df.columns.tolist()
-
-    #     metadata = MetaData()
-    #     table = Table(self.table_name, metadata, autoload_with=self.engine)
-    #     statement = insert(table).values(**{col: df[col] for col in columns})
-
-    #     statement = statement.on_conflict_do_update(
-    #         index_elements=self.index_columns,
-    #         set_={col: getattr(statement.excluded, col) for col in columns},
-    #     )
-    #     records = df.to_dict(orient="records")
-    #     with self.engine.connect() as conn:
-    #         with conn.begin():
-    #             conn.execute(statement, records)
-
     def insert(
         self, data: TypedDataFrame, on_conflict: Literal["update", "nothing"]
     ) -> None:
         """Insert data from a DataFrame into a SQL table.
 
+        :param on_conflict: choice for "ON CONFLICT" clause.
         :param data: Typed pandas DataFrame containing the data to upsert.
         """
         if not self.table_exists():

--- a/src/destinations/postgres.py
+++ b/src/destinations/postgres.py
@@ -9,7 +9,7 @@ from sqlalchemy.dialects.postgresql import insert
 from src.interfaces import Destination, TypedDataFrame
 from src.logger import log
 
-TableExistsPolicy = Literal["append", "replace", "upsert"]
+TableExistsPolicy = Literal["append", "replace", "upsert", "insert_ignore"]
 
 
 class PostgresDestination(Destination[TypedDataFrame]):
@@ -26,7 +26,7 @@ class PostgresDestination(Destination[TypedDataFrame]):
         The name of the destination table in PostgreSQL where data will be saved.
     if_exists : TableExistsPolicy
         Policy for handling existing tables:
-            "replace", "append", "upsert" (default is "append").
+            "replace", "append", "upsert", "insert_ignore" (default is "append").
 
     Methods
     -------
@@ -125,7 +125,9 @@ class PostgresDestination(Destination[TypedDataFrame]):
             return
         match self.if_exists:
             case "upsert":
-                self.upsert(data)
+                self.insert(data, on_conflict="update")
+            case "insert_ignore":
+                self.insert(data, on_conflict="nothing")
             case "append":
                 self.append(data)
             case "replace":
@@ -164,8 +166,38 @@ class PostgresDestination(Destination[TypedDataFrame]):
                 dtype=dtypes,
             )
 
-    def upsert(self, data: TypedDataFrame) -> None:
-        """Upsert data from a DataFrame into a SQL table.
+    # def upsert(self, data: TypedDataFrame) -> None:
+    #     """Upsert data from a DataFrame into a SQL table.
+
+    #     :param data: Typed pandas DataFrame containing the data to upsert.
+    #     """
+    #     if not self.table_exists():
+    #         # Do append.
+    #         self.append(data)
+    #         return
+
+    #     self.validate_unique_constraints()
+    #     df, _ = data
+    #     # Get all column names from the DataFrame
+    #     columns = df.columns.tolist()
+
+    #     metadata = MetaData()
+    #     table = Table(self.table_name, metadata, autoload_with=self.engine)
+    #     statement = insert(table).values(**{col: df[col] for col in columns})
+
+    #     statement = statement.on_conflict_do_update(
+    #         index_elements=self.index_columns,
+    #         set_={col: getattr(statement.excluded, col) for col in columns},
+    #     )
+    #     records = df.to_dict(orient="records")
+    #     with self.engine.connect() as conn:
+    #         with conn.begin():
+    #             conn.execute(statement, records)
+
+    def insert(
+        self, data: TypedDataFrame, on_conflict: Literal["update", "nothing"]
+    ) -> None:
+        """Insert data from a DataFrame into a SQL table.
 
         :param data: Typed pandas DataFrame containing the data to upsert.
         """
@@ -183,10 +215,15 @@ class PostgresDestination(Destination[TypedDataFrame]):
         table = Table(self.table_name, metadata, autoload_with=self.engine)
         statement = insert(table).values(**{col: df[col] for col in columns})
 
-        statement = statement.on_conflict_do_update(
-            index_elements=self.index_columns,
-            set_={col: getattr(statement.excluded, col) for col in columns},
-        )
+        if on_conflict == "update":
+            statement = statement.on_conflict_do_update(
+                index_elements=self.index_columns,
+                set_={col: getattr(statement.excluded, col) for col in columns},
+            )
+        else:  # nothing
+            statement = statement.on_conflict_do_nothing(
+                index_elements=self.index_columns,
+            )
         records = df.to_dict(orient="records")
         with self.engine.connect() as conn:
             with conn.begin():

--- a/tests/unit/destinations_test.py
+++ b/tests/unit/destinations_test.py
@@ -222,7 +222,7 @@ class PostgresDestinationTest(unittest.TestCase):
 
         drop_table(pg_dest.engine, table_name)
         # This upsert would create table (since it doesn't exist yet)
-        pg_dest.upsert((df1, {}))
+        pg_dest.insert((df1, {}), on_conflict="update")
         self.assertEqual(
             [{"id": 1, "value": "alice"}, {"id": 2, "value": "bob"}],
             select_star(pg_dest.engine, table_name),
@@ -237,7 +237,7 @@ class PostgresDestinationTest(unittest.TestCase):
                 """,
         )
         # This would insert with no conflict or update.
-        pg_dest.upsert((df2, {}))
+        pg_dest.insert((df2, {}), on_conflict="update")
         self.assertEqual(
             [
                 {"id": 1, "value": "alice"},
@@ -248,11 +248,12 @@ class PostgresDestinationTest(unittest.TestCase):
             select_star(pg_dest.engine, table_name),
         )
         # overwrite some columns with max
-        pg_dest.upsert(
+        pg_dest.insert(
             (
                 pd.DataFrame({"id": [3, 4, 5], "value": ["max", "max", "erik"]}),
                 {},
-            )
+            ),
+            on_conflict="update",
         )
         self.assertEqual(
             [

--- a/tests/unit/destinations_test.py
+++ b/tests/unit/destinations_test.py
@@ -217,14 +217,14 @@ class PostgresDestinationTest(unittest.TestCase):
             if_exists="upsert",
             index_columns=["id"],
         )
-        df1 = pd.DataFrame({"id": [1, 2], "value": ["alice", "bob"]})
-        df2 = pd.DataFrame({"id": [3, 4], "value": ["chuck", "dave"]})
+        df1 = pd.DataFrame({"id": [1], "value": ["alice"]})
+        df2 = pd.DataFrame({"id": [2], "value": ["bob"]})
 
         drop_table(pg_dest.engine, table_name)
         # This upsert would create table (since it doesn't exist yet)
         pg_dest.insert((df1, {}), on_conflict="update")
         self.assertEqual(
-            [{"id": 1, "value": "alice"}, {"id": 2, "value": "bob"}],
+            [{"id": 1, "value": "alice"}],
             select_star(pg_dest.engine, table_name),
         )
         # Add id constraint:
@@ -242,15 +242,13 @@ class PostgresDestinationTest(unittest.TestCase):
             [
                 {"id": 1, "value": "alice"},
                 {"id": 2, "value": "bob"},
-                {"id": 3, "value": "chuck"},
-                {"id": 4, "value": "dave"},
             ],
             select_star(pg_dest.engine, table_name),
         )
         # overwrite some columns with max
         pg_dest.insert(
             (
-                pd.DataFrame({"id": [3, 4, 5], "value": ["max", "max", "erik"]}),
+                pd.DataFrame({"id": [2, 3], "value": ["max", "chuck"]}),
                 {},
             ),
             on_conflict="update",
@@ -258,10 +256,8 @@ class PostgresDestinationTest(unittest.TestCase):
         self.assertEqual(
             [
                 {"id": 1, "value": "alice"},
-                {"id": 2, "value": "bob"},
-                {"id": 3, "value": "max"},
-                {"id": 4, "value": "max"},
-                {"id": 5, "value": "erik"},
+                {"id": 2, "value": "max"},
+                {"id": 3, "value": "chuck"},
             ],
             select_star(pg_dest.engine, table_name),
         )
@@ -277,14 +273,14 @@ class PostgresDestinationTest(unittest.TestCase):
             if_exists="insert_ignore",
             index_columns=["id"],
         )
-        df1 = pd.DataFrame({"id": [1, 2], "value": ["alice", "bob"]})
-        df2 = pd.DataFrame({"id": [3, 4], "value": ["chuck", "dave"]})
+        df1 = pd.DataFrame({"id": [1], "value": ["alice"]})
+        df2 = pd.DataFrame({"id": [2], "value": ["bob"]})
 
         drop_table(pg_dest.engine, table_name)
         # This upsert would create table (since it doesn't exist yet)
         pg_dest.insert((df1, {}), on_conflict="nothing")
         self.assertEqual(
-            [{"id": 1, "value": "alice"}, {"id": 2, "value": "bob"}],
+            [{"id": 1, "value": "alice"}],
             select_star(pg_dest.engine, table_name),
         )
         # Add id constraint:
@@ -299,18 +295,13 @@ class PostgresDestinationTest(unittest.TestCase):
         # This would insert with no conflict or update.
         pg_dest.insert((df2, {}), on_conflict="nothing")
         self.assertEqual(
-            [
-                {"id": 1, "value": "alice"},
-                {"id": 2, "value": "bob"},
-                {"id": 3, "value": "chuck"},
-                {"id": 4, "value": "dave"},
-            ],
+            [{"id": 1, "value": "alice"}, {"id": 2, "value": "bob"}],
             select_star(pg_dest.engine, table_name),
         )
         # overwrite some columns with max
         pg_dest.insert(
             (
-                pd.DataFrame({"id": [3, 4, 5], "value": ["max", "max", "erik"]}),
+                pd.DataFrame({"id": [2, 3], "value": ["max", "chuck"]}),
                 {},
             ),
             on_conflict="nothing",
@@ -320,15 +311,12 @@ class PostgresDestinationTest(unittest.TestCase):
                 {"id": 1, "value": "alice"},
                 {"id": 2, "value": "bob"},
                 {"id": 3, "value": "chuck"},
-                {"id": 4, "value": "dave"},
-                {"id": 5, "value": "erik"},
             ],
             select_star(pg_dest.engine, table_name),
         )
 
         # Clean up
         drop_table(pg_dest.engine, table_name)
-
 
     def test_replace(self):
         table_name = "test_replace"


### PR DESCRIPTION
Something analogous to upsert except on conflict do nothing instead of do update.

~~I also noticed that our existing "test" doesn't actually confirm that upsert actually works as expected, since the values in the test query are static.~~

~~I would like add some tests here (hence the draft state) and also propose that we include the return statements from the query executions (i.e. returning number of records updated, inserted, etc). This would help confirm what we have here.~~

Update: The failing tests in the first commit we can confirm the functionality of upsert. Added a test for insert ignore.

