### PR TITLE
Throw an error when the container encounters an error

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,7 @@ async def main(jobs: list[Job]) -> None:
             await completed_task
         except Exception as e:  # pylint: disable=broad-exception-caught
             log.error("Error in job execution: %s", str(e))
+            raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
At the moment the `src/main.py` script catches all errors and logs them. This means that the Docker container does not exit with a failing status code when the job does not succeed.

For example:
>[ERROR] dune-sync:main.main:44 - Error in job execution: HTTPSConnectionPool(host='api.dune.com', port=443): Max retries exceeded with url: /api/v1/table/upload/csv (Caused by ReadTimeoutError("HTTPSConnectionPool(host='api.dune.com', port=443): Read timed out. (read timeout=10)"))

This PR modifies the error handling to re-raises the error after logging it so that the container exits with a non-zero exit code when the job fails.