### PR TITLE
Trigger test suite on pushes to forks.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,6 @@
 name: End to End Test
-on: push
+on:
+  - pull_request
 
 jobs:
   db-job:


### PR DESCRIPTION
`on: push` apparently does not do that by default, see https://github.com/orgs/community/discussions/50736