### PR TITLE
HotFix: PG to PG is empty bug

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,3 +48,11 @@ jobs:
       ref: PG
       table_name: cow.solvers
       if_exists: replace
+
+  - name: p2p-test
+    source:
+      ref: PG
+      query_string: "SELECT 1 as number, '\\x1234'::bytea as my_bytes;"
+    destination:
+      ref: PG
+      table_name: aurelie.p2p-test

--- a/config.yaml
+++ b/config.yaml
@@ -55,4 +55,4 @@ jobs:
       query_string: "SELECT 1 as number, '\\x1234'::bytea as my_bytes;"
     destination:
       ref: PG
-      table_name: aurelie.p2p-test
+      table_name: moo.p2p-test

--- a/tests/unit/sources_test.py
+++ b/tests/unit/sources_test.py
@@ -9,6 +9,7 @@ from sqlalchemy import BIGINT
 from sqlalchemy.dialects.postgresql import BYTEA
 
 from src.config import RuntimeConfig
+from src.interfaces import TypedDataFrame
 from src.sources.dune import _reformat_varbinary_columns, dune_result_to_df
 from src.sources.postgres import PostgresSource, _convert_bytea_to_hex
 from tests import config_root, fixtures_root
@@ -136,5 +137,4 @@ class TestPostgresSource(unittest.TestCase):
             db_url="postgresql://postgres:postgres@localhost:5432/postgres",
             query_string="SELECT 1",
         )
-        df = pd.DataFrame([])
-        self.assertTrue(src.is_empty(df))
+        self.assertTrue(src.is_empty(TypedDataFrame(pd.DataFrame([]), {})))


### PR DESCRIPTION
There was an inconsistency with the types returned from postgres and those being passed in. 

PG.fetch returned `DataFrame`
but 
PG.save expected `TypedDataFrame`

Resulted in a bug where data.is_empty did not exist. 

This PR aligns the types naively, but this will all be improved in a follow up #129 (which assigns proper/non-empty types) to Postgres dataframes.