### PR TITLE
Handle bytea[] types on p2p

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -53,11 +53,12 @@ jobs:
     source:
       ref: PG
       query_string: |
-        SELECT 
-          1 AS number, 
+        SELECT
+          1 AS number,
           '\\x1234'::bytea AS my_bytes,
-          '{"key": "value", "array": [1, 2, 3], "dict": {}}'::json AS my_json,
-          '[ [{"x": 1}, {"y": 2}], null, [{"z": 3}] ]'::json AS list_dict
+          ARRAY['\\x1234'::bytea, '\\x5678'::bytea] AS array_bytea,
+          '{"key": "value", "array": [1, 2, 3], "dict": {}}'::json AS my_json
+          -- '[ [{"x": 1}, {"y": 2}], null, [{"z": 3}] ]'::json AS list_dict
 
     destination:
       ref: PG

--- a/config.yaml
+++ b/config.yaml
@@ -58,7 +58,6 @@ jobs:
           '\\x1234'::bytea AS my_bytes,
           ARRAY['\\x1234'::bytea, '\\x5678'::bytea] AS array_bytea,
           '{"key": "value", "array": [1, 2, 3], "dict": {}}'::json AS my_json
-          -- '[ [{"x": 1}, {"y": 2}], null, [{"z": 3}] ]'::json AS list_dict
 
     destination:
       ref: PG

--- a/src/sources/postgres.py
+++ b/src/sources/postgres.py
@@ -140,8 +140,9 @@ class PostgresSource(Source[TypedDataFrame]):
         df = await loop.run_in_executor(
             None, lambda: pd.read_sql_query(self.query_string, con=self.engine)
         )
-        df = _convert_bytea_to_hex(df)
+
         df = _convert_dict_to_json(df)
+        df = _convert_bytea_to_hex(df)
         # TODO include types.
         return TypedDataFrame(dataframe=df, types={})
 

--- a/src/sources/postgres.py
+++ b/src/sources/postgres.py
@@ -57,10 +57,6 @@ def _convert_bytea_to_hex(df: DataFrame) -> DataFrame:
     for column in df.columns:
         if isinstance(df[column].iloc[0], memoryview):
             df[column] = df[column].apply(lambda x: f"0x{x.tobytes().hex()}")
-        # if isinstance(df[column].iloc[0], list):
-        #     # Check if the list contains memoryview objects
-        #     if all(isinstance(item, memoryview) for item in df[column].iloc[0]):
-        #         df[column] = df[column].apply(lambda lst: [f"0x{item.tobytes().hex()}" for item in lst])
     return df
 
 

--- a/tests/unit/sources_test.py
+++ b/tests/unit/sources_test.py
@@ -99,13 +99,6 @@ class TestSourceUtils(unittest.TestCase):
             None,
         ]
 
-        # Assert list of dictionaries was converted
-        assert result["list_dict"].tolist() == [
-            '[{"x": 1}, {"y": 2}]',
-            None,
-            '[{"z": 3}]',
-        ]
-
         # Assert normal column remains unchanged
         assert result["normal_col"].tolist() == [1, 2, 3]
 


### PR DESCRIPTION
An attempt to mitigate the issue #137 (with a trade-off: lose support for `array[dict]`).